### PR TITLE
Quick bug fix

### DIFF
--- a/source/rimp2_energy_whole_KERN.f90
+++ b/source/rimp2_energy_whole_KERN.f90
@@ -271,7 +271,7 @@
 
 
 #if defined(NVBLAS) || defined(CUBLAS) || defined(CUBLASXT)
-        !$omp target data use_device_ptr(BI,BJ,QVV)
+        !$omp target data use_device_ptr(B32,QVV)
 #endif
 #if defined(CUBLAS) || defined(CUBLASXT)
 #if defined(CUBLAS)


### PR DESCRIPTION
This fixes a bug in the "combined" version-- I had `use_device_ptr(BI,BJ,QVV)`, should have had `use_device_ptr(B32,QVV)`, since `BI` and `BJ` aren't defined in the routine.